### PR TITLE
PKGBUILD improvements

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,25 +1,18 @@
 # Maintainer: Mirdarthos mirdarthos[at]duck[dot]com
 
 pkgname=my-universal-manjaro-update-helper
-pkgver=v2.1
+pkgver=2.1
 pkgrel=1
-pkgdesc="a Helper for updating your Manjaro Linux."
+pkgdesc="A helper for updating Manjaro Linux."
 arch=('any')
 url="https://github.com/Mirdarthos/manjaro-update-helper"
-license=('Apache2')
+license=('Apache')
 depends=('xsel' 'ncurses' 'pamac-cli' 'pacman' 'inxi' 'meld')
-makedepends=()
 optdepends=('timeshift: For creating backups with prior to updating if custom command not specified.')
-
-source=("manjaro-update-helper.zip::https://github.com/Mirdarthos/manjaro-update-helper/archive/refs/heads/master.zip")
-sha256sums=('SKIP')
-
-conflicts=()
-replaces=()
-backup=()
+source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/V$pkgver.tar.gz")
+sha256sums=('3af96ecfa322e05b5ca5e216abf1fc879f62466e58ec79e255a4b44a01ed2b70')
 
 package() {
-    # unzip manjaro-update-helper.zip
-    sudo install --owner=root --group=root --mode=0355 "${srcdir}/manjaro-update-helper-master/src/usr/bin/mumuh" --target-directory="/usr/bin/"
-    sudo rm --force --recursive "${srcdir}/manjaro-update-helper-master"
+    cd manjaro-update-helper-$pkgver
+    install -Dm755 src/usr/bin/mumuh -t "$pkgdir/usr/bin/"
 }


### PR DESCRIPTION
- Do not include the leading v in the pkgver
- Apache is the name of the common license already installed in `/usr/share/licenses/common/`
- Use the release tarball and do not skip checksums. A [VCS package](https://wiki.archlinux.org/title/VCS_package_guidelines) can be created if you want to pull directly from the latest commit
- Do not use sudo. The package() function runs in a fakeroot environment. Pacman will be called to install the package with elevated privileges.